### PR TITLE
Use `ValidationBlocksPerSlot` protocol parameter

### DIFF
--- a/components/validator/issuer.go
+++ b/components/validator/issuer.go
@@ -96,13 +96,13 @@ func committeeMemberAction(ctx context.Context) {
 		}
 	}
 
-	// Schedule next committeeMemberAction regardless of whether the node is bootstrapped or validator block is issued
+	// Schedule next committeeMemberAction regardless of whether the node is bootstrapped or validation block is issued
 	// as it must be issued as part of validator's responsibility.
 	executor.ExecuteAt(CommitteeTask, func() { committeeMemberAction(ctx) }, now.Add(committeeBroadcastInterval))
 
 	// If we are not bootstrapped and we are _not_ ignoring such condition, we return.
 	if !deps.NodeBridge.NodeStatus().GetIsBootstrapped() && !ParamsValidator.IgnoreBootstrapped {
-		Component.LogDebug("not issuing validator block because node is not bootstrapped yet.")
+		Component.LogDebug("not issuing validation block because node is not bootstrapped yet.")
 
 		return
 	}
@@ -152,7 +152,7 @@ func issueCandidateBlock(ctx context.Context, blockIssuingTime time.Time, curren
 	return nil
 }
 
-func issueValidatorBlock(ctx context.Context, blockIssuingTime time.Time, currentAPI iotago.API) error {
+func issueValidatonBlock(ctx context.Context, blockIssuingTime time.Time, currentAPI iotago.API, committeeBroadcastInterval time.Duration) error {
 	protocolParametersHash, err := currentAPI.ProtocolParameters().Hash()
 	if err != nil {
 		return ierrors.Wrapf(err, "failed to get protocol parameters hash")
@@ -200,10 +200,10 @@ func issueValidatorBlock(ctx context.Context, blockIssuingTime time.Time, curren
 
 	blockID, err := deps.NodeBridge.SubmitBlock(ctx, validationBlock)
 	if err != nil {
-		return ierrors.Wrapf(err, "error issuing validator block")
+		return ierrors.Wrapf(err, "error issuing validation block")
 	}
 
-	Component.LogDebugf("issued validator block: %s - commitment %s %d - latest finalized slot %d", blockID, validationBlock.Header.SlotCommitmentID, validationBlock.Header.SlotCommitmentID.Slot(), validationBlock.Header.LatestFinalizedSlot)
+	Component.LogDebugf("issued validation block: %s - commitment %s %d - latest finalized slot %d - broadcast interval %dms", blockID, validationBlock.Header.SlotCommitmentID, validationBlock.Header.SlotCommitmentID.Slot(), validationBlock.Header.LatestFinalizedSlot, committeeBroadcastInterval.Milliseconds())
 
 	return nil
 }

--- a/components/validator/issuer.go
+++ b/components/validator/issuer.go
@@ -203,7 +203,7 @@ func issueValidationBlock(ctx context.Context, blockIssuingTime time.Time, curre
 		return ierrors.Wrapf(err, "error issuing validation block")
 	}
 
-	Component.LogDebugf("issued validation block: %s - commitment %s %d - latest finalized slot %d - broadcast interval %dms", blockID, validationBlock.Header.SlotCommitmentID, validationBlock.Header.SlotCommitmentID.Slot(), validationBlock.Header.LatestFinalizedSlot, committeeBroadcastInterval.Milliseconds())
+	Component.LogDebugf("issued validation block: %s - commitment %s %d - latest finalized slot %d - broadcast interval %v", blockID, validationBlock.Header.SlotCommitmentID, validationBlock.Header.SlotCommitmentID.Slot(), validationBlock.Header.LatestFinalizedSlot, committeeBroadcastInterval.Truncate(time.Millisecond))
 
 	return nil
 }

--- a/components/validator/issuer.go
+++ b/components/validator/issuer.go
@@ -109,7 +109,7 @@ func committeeMemberAction(ctx context.Context) {
 
 	// If we are either bootstrapped (and we are part of the committee) or we are ignoring being bootstrapped we issue
 	// a validation block, reviving the chain if necessary.
-	if err := issueValidatonBlock(ctx, now, currentAPI, committeeBroadcastInterval); err != nil {
+	if err := issueValidationBlock(ctx, now, currentAPI, committeeBroadcastInterval); err != nil {
 		Component.LogWarnf("error while trying to issue validation block: %s", err.Error())
 	}
 }
@@ -152,7 +152,7 @@ func issueCandidateBlock(ctx context.Context, blockIssuingTime time.Time, curren
 	return nil
 }
 
-func issueValidatonBlock(ctx context.Context, blockIssuingTime time.Time, currentAPI iotago.API, committeeBroadcastInterval time.Duration) error {
+func issueValidationBlock(ctx context.Context, blockIssuingTime time.Time, currentAPI iotago.API, committeeBroadcastInterval time.Duration) error {
 	protocolParametersHash, err := currentAPI.ProtocolParameters().Hash()
 	if err != nil {
 		return ierrors.Wrapf(err, "failed to get protocol parameters hash")

--- a/components/validator/params.go
+++ b/components/validator/params.go
@@ -8,8 +8,6 @@ import (
 
 // ParametersValidator contains the definition of the configuration parameters used by the Validator component.
 type ParametersValidator struct {
-	// CommitteeBroadcastInterval the interval at which the node will broadcast its committee validator block.
-	CommitteeBroadcastInterval time.Duration `default:"500ms" usage:"the interval at which committee validator block will be broadcast"`
 	// CandidacyRetryInterval the interval at which broadcast of candidacy announcement block will be retried
 	CandidacyRetryInterval time.Duration `default:"10s" usage:"the interval at which broadcast of candidacy announcement block will be retried"`
 	// IssueCandidacyPayload sets whether the node should issue a candidacy payload.

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -29,7 +29,6 @@
     "targetNetworkName": ""
   },
   "validator": {
-    "committeeBroadcastInterval": "500ms",
     "candidacyRetryInterval": "10s",
     "issueCandidacyPayload": true,
     "ignoreBootstrapped": false,

--- a/configuration.md
+++ b/configuration.md
@@ -129,20 +129,18 @@ Example:
 
 ## <a id="validator"></a> 4. Validator
 
-| Name                       | Description                                                                                                  | Type    | Default value |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ------------- |
-| committeeBroadcastInterval | The interval at which committee validator block will be broadcast                                            | string  | "500ms"       |
-| candidacyRetryInterval     | The interval at which broadcast of candidacy announcement block will be retried                              | string  | "10s"         |
-| issueCandidacyPayload      | Whether the node should issue a candidacy payload                                                            | boolean | true          |
-| ignoreBootstrapped         | Whether the Validator component should start issuing validator blocks before the main engine is bootstrapped | boolean | false         |
-| accountAddress             | The account address of the validator account that will issue the blocks                                      | string  | ""            |
+| Name                   | Description                                                                                                  | Type    | Default value |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ------------- |
+| candidacyRetryInterval | The interval at which broadcast of candidacy announcement block will be retried                              | string  | "10s"         |
+| issueCandidacyPayload  | Whether the node should issue a candidacy payload                                                            | boolean | true          |
+| ignoreBootstrapped     | Whether the Validator component should start issuing validator blocks before the main engine is bootstrapped | boolean | false         |
+| accountAddress         | The account address of the validator account that will issue the blocks                                      | string  | ""            |
 
 Example:
 
 ```json
   {
     "validator": {
-      "committeeBroadcastInterval": "500ms",
       "candidacyRetryInterval": "10s",
       "issueCandidacyPayload": true,
       "ignoreBootstrapped": false,


### PR DESCRIPTION
Use `ValidationBlocksPerSlot` protocol parameter in the calculation for how often a validation block should be issued per slot.