### PR TITLE
Bump iota.go to auto-set `NetworkID` in builder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/iotaledger/hive.go/ierrors v0.0.0-20231128121006-331a9e522dfe
 	github.com/iotaledger/hive.go/runtime v0.0.0-20231128121006-331a9e522dfe
 	github.com/iotaledger/inx-app v1.0.0-rc.3.0.20231128163614-c82e1fa40733
-	github.com/iotaledger/iota.go/v4 v4.0.0-20231128162016-23f1b4e12cec
+	github.com/iotaledger/iota.go/v4 v4.0.0-20231201103607-03a45ba3707f
 	go.uber.org/dig v1.17.1
 
 )

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/iotaledger/inx-app v1.0.0-rc.3.0.20231128163614-c82e1fa40733 h1:jdjFT
 github.com/iotaledger/inx-app v1.0.0-rc.3.0.20231128163614-c82e1fa40733/go.mod h1:3ae5TFi3uaECV+F4d5ekKz+xcJQmVtCICcs/Rhvgn3w=
 github.com/iotaledger/inx/go v1.0.0-rc.2.0.20231128162307-cc6b309e93ef h1:RImO23W0kL3U9egdLoi5OTmOIhE5rHfR/dKM/6XhZeE=
 github.com/iotaledger/inx/go v1.0.0-rc.2.0.20231128162307-cc6b309e93ef/go.mod h1:bi0zndM3irf8FHYUg6MzG/Zk/t0fV8IwGXAdoT7wn98=
-github.com/iotaledger/iota.go/v4 v4.0.0-20231128162016-23f1b4e12cec h1:u9SAuKHygJwqwYxoEd+PyHCU4fTftcPdV2ZUGSRZe8o=
-github.com/iotaledger/iota.go/v4 v4.0.0-20231128162016-23f1b4e12cec/go.mod h1:aO+5iL0vTNwNfE4QMGHVIufGziSI1wTvwJY1ipSMgCk=
+github.com/iotaledger/iota.go/v4 v4.0.0-20231201103607-03a45ba3707f h1:uT4ZKAyr/wk6lHcTQifAeEPb6WfBA5tdG7kEuyW7tDU=
+github.com/iotaledger/iota.go/v4 v4.0.0-20231201103607-03a45ba3707f/go.mod h1:aO+5iL0vTNwNfE4QMGHVIufGziSI1wTvwJY1ipSMgCk=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=


### PR DESCRIPTION
Bump iota.go to auto-set `NetworkID` in builder which is required after iotaledger/iota.go#627.